### PR TITLE
[Android] 유저 > 로그인, 회원가입 API 연동 추가

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
+        android:usesCleartextTraffic="true"
         android:name=".AndroidApplication"
         android:allowBackup="false"
         android:supportsRtl="true"

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlinCocoapods)
     alias(libs.plugins.androidLibrary)
     alias(libs.plugins.compose)
+    kotlin("plugin.serialization") version "1.9.21"
 }
 
 @OptIn(org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi::class)

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/Platform.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/Platform.kt
@@ -1,9 +1,13 @@
 package com.jinkyu.tv
 
 import androidx.media3.exoplayer.ExoPlayer
+import com.jinkyu.tv.presentation.LoginViewModel
 import com.jinkyu.tv.presentation.MainViewModel
+import com.jinkyu.tv.presentation.RegisterViewModel
 import com.jinkyu.tv.presentation.player.PlayerViewModel
 import com.jinkyu.tv.presentation.splash.AndroidSplashViewModel
+import com.jinkyu.tv.presentation.register.AndroidRegisterViewModel
+import com.jinkyu.tv.presentation.login.AndroidLoginViewModel
 import com.jinkyu.tv.presentation.splash.SplashViewModel
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
@@ -22,5 +26,13 @@ actual fun platformModule() = module {
     factory { param ->
         PlayerViewModel()
     }
+    factory { params ->
+        RegisterViewModel(params.get())
+    }
+    factory { params ->
+        LoginViewModel(params.get())
+    }
     viewModelOf(::AndroidSplashViewModel)
+    viewModelOf(::AndroidRegisterViewModel)
+    viewModelOf(::AndroidLoginViewModel)
 }

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/Platform.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/Platform.kt
@@ -12,11 +12,21 @@ import com.jinkyu.tv.presentation.register.AndroidRegisterViewModel
 import com.jinkyu.tv.presentation.login.AndroidLoginViewModel
 import com.jinkyu.tv.presentation.splash.SplashViewModel
 import io.ktor.client.HttpClient
+import io.ktor.client.engine.android.Android
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
 
 actual fun platformModule() = module {
-    single<HttpClient> { HttpClient() }
+    single<HttpClient> {
+        HttpClient(Android) {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+
+    }
     single<UserRepository> { UserRepositoryImpl(get()) }
     factory { params ->
         SplashViewModel(params.get())

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/Platform.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/Platform.kt
@@ -1,9 +1,9 @@
 package com.jinkyu.tv
 
 import androidx.media3.exoplayer.ExoPlayer
-import com.jinkyu.tv.presentation.LoginViewModel
+import com.jinkyu.tv.presentation.login.LoginViewModel
 import com.jinkyu.tv.presentation.MainViewModel
-import com.jinkyu.tv.presentation.RegisterViewModel
+import com.jinkyu.tv.presentation.register.RegisterViewModel
 import com.jinkyu.tv.presentation.player.PlayerViewModel
 import com.jinkyu.tv.presentation.splash.AndroidSplashViewModel
 import com.jinkyu.tv.presentation.register.AndroidRegisterViewModel

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/Platform.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/Platform.kt
@@ -6,12 +6,6 @@ import com.jinkyu.tv.presentation.player.PlayerViewModel
 import com.jinkyu.tv.presentation.splash.AndroidSplashViewModel
 import com.jinkyu.tv.presentation.splash.SplashViewModel
 import org.koin.androidx.viewmodel.dsl.viewModelOf
-import org.koin.core.module.dsl.factoryOf
-import com.jinkyu.tv.presentation.player.PlayerViewModel
-import com.jinkyu.tv.presentation.splash.AndroidSplashViewModel
-import com.jinkyu.tv.presentation.splash.SplashViewModel
-import org.koin.androidx.viewmodel.dsl.viewModelOf
-import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
 
 actual fun platformModule() = module {

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/Platform.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/Platform.kt
@@ -41,7 +41,7 @@ actual fun platformModule() = module {
         PlayerViewModel()
     }
     factory { params ->
-        RegisterViewModel(params.get())
+        RegisterViewModel(params.get(), params.get())
     }
     factory { params ->
         LoginViewModel(params.get(), params.get())

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/Platform.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/Platform.kt
@@ -1,6 +1,8 @@
 package com.jinkyu.tv
 
 import androidx.media3.exoplayer.ExoPlayer
+import com.jinkyu.tv.data.UserRepository
+import com.jinkyu.tv.data.UserRepositoryImpl
 import com.jinkyu.tv.presentation.login.LoginViewModel
 import com.jinkyu.tv.presentation.MainViewModel
 import com.jinkyu.tv.presentation.register.RegisterViewModel
@@ -9,11 +11,13 @@ import com.jinkyu.tv.presentation.splash.AndroidSplashViewModel
 import com.jinkyu.tv.presentation.register.AndroidRegisterViewModel
 import com.jinkyu.tv.presentation.login.AndroidLoginViewModel
 import com.jinkyu.tv.presentation.splash.SplashViewModel
+import io.ktor.client.HttpClient
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.dsl.module
 
 actual fun platformModule() = module {
-
+    single<HttpClient> { HttpClient() }
+    single<UserRepository> { UserRepositoryImpl(get()) }
     factory { params ->
         SplashViewModel(params.get())
     }
@@ -30,7 +34,7 @@ actual fun platformModule() = module {
         RegisterViewModel(params.get())
     }
     factory { params ->
-        LoginViewModel(params.get())
+        LoginViewModel(params.get(), params.get())
     }
     viewModelOf(::AndroidSplashViewModel)
     viewModelOf(::AndroidRegisterViewModel)

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/AppNavHost.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/AppNavHost.kt
@@ -45,7 +45,7 @@ fun AppNavHost(
             route = Register.route
         ) {
             RegisterRoute(
-                navigateLogin = { navController.navigateLogin() },
+                navigateLogin = { navController.navigateUp() },
                 navigateMain = { navController.navigateMain() }
             )
         }

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/AppNavHost.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/AppNavHost.kt
@@ -34,7 +34,7 @@ fun AppNavHost(
             )
         }
         composable(
-            route = "login"
+            route = Login.route
         ) {
             LoginRoute(
                 navigateMain = { navController.navigateMain() },
@@ -42,7 +42,7 @@ fun AppNavHost(
             )
         }
         composable(
-            route = "register"
+            route = Register.route
         ) {
             RegisterRoute(
                 navigateLogin = { navController.navigateLogin() },

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/AppNavHost.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/AppNavHost.kt
@@ -34,7 +34,8 @@ fun AppNavHost(
             )
         }
         composable(
-            route = Login.route
+            route = Login.route,
+            enterTransition = { slideInFromRight() }
         ) {
             LoginRoute(
                 navigateMain = { navController.navigateMain() },
@@ -42,7 +43,8 @@ fun AppNavHost(
             )
         }
         composable(
-            route = Register.route
+            route = Register.route,
+            enterTransition = { slideInFromRight() }
         ) {
             RegisterRoute(
                 navigateLogin = { navController.navigateUp() },
@@ -50,7 +52,8 @@ fun AppNavHost(
             )
         }
         composable(
-            route = Main.route
+            route = Main.route,
+            enterTransition = { slideInFromRight() }
         ) {
             MainScreen()
         }
@@ -61,4 +64,4 @@ fun AnimatedContentTransitionScope<NavBackStackEntry>.slideInFromRight() =
     slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Left)
 
 fun AnimatedContentTransitionScope<NavBackStackEntry>.slideOutToRight() =
-    slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Right)
+    slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Right)

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/AppNavHost.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/AppNavHost.kt
@@ -9,13 +9,9 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.jinkyu.tv.MainScreen
-import com.jinkyu.tv.RegisterScreen
-import com.jinkyu.tv.presentation.RegisterViewModel
 import com.jinkyu.tv.presentation.login.LoginRoute
 import com.jinkyu.tv.presentation.register.RegisterRoute
-import com.jinkyu.tv.presentation.splash.AndroidSplashViewModel
 import com.jinkyu.tv.presentation.splash.SplashRoute
-import com.jinkyu.tv.presentation.splash.SplashScreen
 
 @Composable
 fun AppNavHost(
@@ -49,7 +45,8 @@ fun AppNavHost(
             route = "register"
         ) {
             RegisterRoute(
-                navigateLogin = { navController.navigateLogin() }
+                navigateLogin = { navController.navigateLogin() },
+                navigateMain = { navController.navigateMain() }
             )
         }
         composable(

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/AppNavHost.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/AppNavHost.kt
@@ -11,6 +11,8 @@ import androidx.navigation.compose.rememberNavController
 import com.jinkyu.tv.MainScreen
 import com.jinkyu.tv.RegisterScreen
 import com.jinkyu.tv.presentation.RegisterViewModel
+import com.jinkyu.tv.presentation.login.LoginRoute
+import com.jinkyu.tv.presentation.register.RegisterRoute
 import com.jinkyu.tv.presentation.splash.AndroidSplashViewModel
 import com.jinkyu.tv.presentation.splash.SplashRoute
 import com.jinkyu.tv.presentation.splash.SplashScreen
@@ -32,18 +34,23 @@ fun AppNavHost(
         ) {
             SplashRoute(
                 navigateMain = { navController.navigateMain() },
-                navigateSign = { }
+                navigateLogin = { navController.navigateLogin() }
             )
         }
         composable(
             route = "login"
         ) {
-            RegisterScreen(viewModel = RegisterViewModel())
+            LoginRoute(
+                navigateMain = { navController.navigateMain() },
+                navigateRegister = { navController.navigateRegister() }
+            )
         }
         composable(
             route = "register"
         ) {
-            RegisterScreen(viewModel = RegisterViewModel())
+            RegisterRoute(
+                navigateLogin = { navController.navigateLogin() }
+            )
         }
         composable(
             route = Main.route

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/LoginNavigation.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/LoginNavigation.kt
@@ -3,15 +3,15 @@ package com.jinkyu.tv.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 
-internal fun NavController.navigateMain() {
+internal fun NavController.navigateLogin() {
     navigate(
-        route = Main.route,
+        route = Login.route,
         navOptions = NavOptions.Builder()
             .setPopUpTo(Splash.route, true)
             .build(),
     )
 }
 
-internal object Main {
-    const val route: String = "main"
+internal object Login {
+    const val route: String = "login"
 }

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/MainNavigation.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/MainNavigation.kt
@@ -12,6 +12,40 @@ internal fun NavController.navigateMain() {
     )
 }
 
+internal fun NavController.navigateSignUp() {
+    navigate(
+        route = SignUp.route,
+        navOptions = NavOptions.Builder()
+            .setPopUpTo(Splash.route, true)
+            .build(),
+    )
+}
+
+internal fun NavController.navigateLogin() {
+    navigate(
+        route = Login.route,
+        navOptions = NavOptions.Builder()
+            .setPopUpTo(Splash.route, true)
+            .build(),
+    )
+}
+
+internal fun NavController.navigateRegister() {
+    navigate(
+        route = Login.route,
+        navOptions = NavOptions.Builder()
+            .build(),
+    )
+}
+
 internal object Main {
     const val route: String = "main"
+}
+
+internal object SignUp {
+    const val route: String = "signup"
+}
+
+internal object Login {
+    const val route: String = "login"
 }

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/RegisterNavigation.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/RegisterNavigation.kt
@@ -5,9 +5,9 @@ import androidx.navigation.NavOptions
 
 internal fun NavController.navigateRegister() {
     navigate(
-        route = Login.route,
+        route = Register.route,
         navOptions = NavOptions.Builder()
-            .setPopUpTo(Splash.route, true)
+            .setPopUpTo(Register.route, true)
             .build(),
     )
 }

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/RegisterNavigation.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/navigation/RegisterNavigation.kt
@@ -3,15 +3,15 @@ package com.jinkyu.tv.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 
-internal fun NavController.navigateMain() {
+internal fun NavController.navigateRegister() {
     navigate(
-        route = Main.route,
+        route = Login.route,
         navOptions = NavOptions.Builder()
             .setPopUpTo(Splash.route, true)
             .build(),
     )
 }
 
-internal object Main {
-    const val route: String = "main"
+internal object Register {
+    const val route: String = "register"
 }

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/login/AndroidLoginViewModel.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/login/AndroidLoginViewModel.kt
@@ -2,8 +2,6 @@ package com.jinkyu.tv.presentation.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.jinkyu.tv.presentation.LoginViewModel
-import com.jinkyu.tv.presentation.RegisterViewModel
 
 class AndroidLoginViewModel : ViewModel() {
 

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/login/AndroidLoginViewModel.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/login/AndroidLoginViewModel.kt
@@ -2,12 +2,16 @@ package com.jinkyu.tv.presentation.login
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.jinkyu.tv.data.UserRepository
 
-class AndroidLoginViewModel : ViewModel() {
+class AndroidLoginViewModel(
+    private val userRepository: UserRepository
+) : ViewModel() {
 
     val viewModel by lazy {
         LoginViewModel(
-            coroutineScope = viewModelScope
+            coroutineScope = viewModelScope,
+            userRepository = userRepository
         )
     }
 }

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/login/AndroidLoginViewModel.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/login/AndroidLoginViewModel.kt
@@ -1,0 +1,15 @@
+package com.jinkyu.tv.presentation.login
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.jinkyu.tv.presentation.LoginViewModel
+import com.jinkyu.tv.presentation.RegisterViewModel
+
+class AndroidLoginViewModel : ViewModel() {
+
+    val viewModel by lazy {
+        LoginViewModel(
+            coroutineScope = viewModelScope
+        )
+    }
+}

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/login/LoginRoute.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/login/LoginRoute.kt
@@ -1,9 +1,6 @@
 package com.jinkyu.tv.presentation.login
 
 import androidx.compose.runtime.Composable
-import com.jinkyu.tv.LoginScreen
-import com.jinkyu.tv.RegisterScreen
-import com.jinkyu.tv.navigation.Login
 import org.koin.androidx.compose.koinViewModel
 
 @Composable

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/login/LoginRoute.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/login/LoginRoute.kt
@@ -1,0 +1,20 @@
+package com.jinkyu.tv.presentation.login
+
+import androidx.compose.runtime.Composable
+import com.jinkyu.tv.LoginScreen
+import com.jinkyu.tv.RegisterScreen
+import com.jinkyu.tv.navigation.Login
+import org.koin.androidx.compose.koinViewModel
+
+@Composable
+fun LoginRoute(
+    navigateRegister: () -> Unit,
+    navigateMain: () -> Unit,
+    viewModel: AndroidLoginViewModel = koinViewModel()
+) {
+    LoginScreen(
+        navigateRegister = navigateRegister,
+        navigateMain = navigateMain,
+        viewModel = viewModel.viewModel
+    )
+}

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/register/AndroidRegisterViewModel.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/register/AndroidRegisterViewModel.kt
@@ -2,12 +2,16 @@ package com.jinkyu.tv.presentation.register
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.jinkyu.tv.data.UserRepository
 
-class AndroidRegisterViewModel : ViewModel() {
+class AndroidRegisterViewModel(
+    private val userRepository: UserRepository
+) : ViewModel() {
 
     val viewModel by lazy {
         RegisterViewModel(
-            coroutineScope = viewModelScope
+            coroutineScope = viewModelScope,
+            userRepository = userRepository
         )
     }
 }

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/register/AndroidRegisterViewModel.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/register/AndroidRegisterViewModel.kt
@@ -2,7 +2,6 @@ package com.jinkyu.tv.presentation.register
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.jinkyu.tv.presentation.RegisterViewModel
 
 class AndroidRegisterViewModel : ViewModel() {
 

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/register/AndroidRegisterViewModel.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/register/AndroidRegisterViewModel.kt
@@ -1,0 +1,14 @@
+package com.jinkyu.tv.presentation.register
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.jinkyu.tv.presentation.RegisterViewModel
+
+class AndroidRegisterViewModel : ViewModel() {
+
+    val viewModel by lazy {
+        RegisterViewModel(
+            coroutineScope = viewModelScope
+        )
+    }
+}

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/register/RegisterRoute.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/register/RegisterRoute.kt
@@ -1,16 +1,15 @@
-package com.jinkyu.tv.presentation.splash
+package com.jinkyu.tv.presentation.register
 
 import androidx.compose.runtime.Composable
+import com.jinkyu.tv.RegisterScreen
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
-fun SplashRoute(
-    navigateMain: () -> Unit,
+fun RegisterRoute(
     navigateLogin: () -> Unit,
-    viewModel: AndroidSplashViewModel = koinViewModel()
+    viewModel: AndroidRegisterViewModel = koinViewModel()
 ) {
-    SplashScreen(
-        navigateMain = navigateMain,
+    RegisterScreen(
         navigateLogin = navigateLogin,
         viewModel = viewModel.viewModel
     )

--- a/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/register/RegisterRoute.kt
+++ b/shared/src/androidMain/kotlin/com/jinkyu/tv/presentation/register/RegisterRoute.kt
@@ -1,16 +1,17 @@
 package com.jinkyu.tv.presentation.register
 
 import androidx.compose.runtime.Composable
-import com.jinkyu.tv.RegisterScreen
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
 fun RegisterRoute(
+    navigateMain: () -> Unit,
     navigateLogin: () -> Unit,
     viewModel: AndroidRegisterViewModel = koinViewModel()
 ) {
     RegisterScreen(
         navigateLogin = navigateLogin,
+        navigateMain = navigateMain,
         viewModel = viewModel.viewModel
     )
 }

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/App.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/App.kt
@@ -6,9 +6,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.jinkyu.tv.di.commonModule
-import com.jinkyu.tv.presentation.splash.SplashScreen
-import com.jinkyu.tv.presentation.LoginViewModel
-import com.jinkyu.tv.presentation.RegisterViewModel
+import com.jinkyu.tv.presentation.login.LoginViewModel
+import com.jinkyu.tv.presentation.register.RegisterViewModel
 import org.koin.compose.KoinApplication
 
 @Composable

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/App.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/App.kt
@@ -6,8 +6,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.jinkyu.tv.di.commonModule
-import com.jinkyu.tv.presentation.login.LoginViewModel
-import com.jinkyu.tv.presentation.register.RegisterViewModel
 import org.koin.compose.KoinApplication
 
 @Composable
@@ -19,16 +17,11 @@ fun App() {
             )
         }
     ) {
-        val registerViewModel = RegisterViewModel() //koinInject<MainViewModel>()
-        val loginViewModel = LoginViewModel()
-
         Box(
             modifier = Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
             MainScreen()
-            //RegisterScreen(modifier = Modifier.fillMaxSize(), viewModel = registerViewModel)
-            //LoginScreen(modifier = Modifier.fillMaxSize(), viewModel = loginViewModel)
         }
     }
 }

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/LoginScreen.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/LoginScreen.kt
@@ -36,6 +36,8 @@ import com.jinkyu.tv.ui.system.WelcomeLabel
 
 @Composable
 fun LoginScreen(
+    navigateRegister: () -> Unit,
+    navigateMain: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: LoginViewModel
 ) {

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/RegisterScreen.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/RegisterScreen.kt
@@ -38,6 +38,7 @@ import com.jinkyu.tv.ui.system.WelcomeLabel
 
 @Composable
 fun RegisterScreen(
+    navigateLogin: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: RegisterViewModel
 ) {

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/data/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/data/UserRepository.kt
@@ -16,4 +16,6 @@ interface UserRepository {
         email: String,
         password: String
     ): Result<PostLoginResponse?>
+
+    suspend fun getUserName(): Result<String>
 }

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/data/UserRepository.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/data/UserRepository.kt
@@ -10,10 +10,10 @@ interface UserRepository {
         nickName: String,
         email: String,
         password: String
-    ): Result<PostRegisterResponse>
+    ): Result<PostRegisterResponse?>
 
     suspend fun login(
         email: String,
         password: String
-    ): Result<PostLoginResponse>
+    ): Result<PostLoginResponse?>
 }

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/data/UserRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/data/UserRepositoryImpl.kt
@@ -19,7 +19,7 @@ class UserRepositoryImpl(
         nickName: String,
         email: String,
         password: String
-    ): Result<PostRegisterResponse> {
+    ): Result<PostRegisterResponse?> {
         val request = PostRegisterRequest(nickName = nickName, id = email, email = email, password = password)
         runCatching {
             httpClient.post {
@@ -42,7 +42,7 @@ class UserRepositoryImpl(
     override suspend fun login(
         email: String,
         password: String
-    ): Result<PostLoginResponse> {
+    ): Result<PostLoginResponse?> {
         val request = PostLoginRequest(id = email, password = password)
         runCatching {
             httpClient.post {
@@ -54,11 +54,11 @@ class UserRepositoryImpl(
             val result = it.body<BaseResponse<PostLoginResponse>>()
             return when (result.isSuccess) {
                 true -> Result.Success(result.result)
-                false -> Result.Error(Throwable(message = result.message))
+                false -> Result.Error(Throwable(message = "아이디 또는 비밀번호를 확인해주세요."))
             }
         }.onFailure {
             return Result.Error(it)
         }
-        return Result.Error(Throwable("네트워크 연동에 실패했습니다."))
+        return Result.Error(Throwable("네트워크 연결에 실패했습니다."))
     }
 }

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/data/UserRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/data/UserRepositoryImpl.kt
@@ -20,7 +20,7 @@ class UserRepositoryImpl(
         email: String,
         password: String
     ): Result<PostRegisterResponse?> {
-        val request = PostRegisterRequest(nickName = nickName, id = email, email = email, password = password)
+        val request = PostRegisterRequest(userName = nickName, id = email, email = email, password = password)
         runCatching {
             httpClient.post {
                 url(NetworkConstants.BASE_URL + "/users")

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/BaseResponse.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/BaseResponse.kt
@@ -1,5 +1,8 @@
 package com.jinkyu.tv.data.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 open class BaseResponse<T>(
     val isSuccess: Boolean = false,
     val code: Int = 0,

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/BaseResponse.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/BaseResponse.kt
@@ -7,5 +7,9 @@ open class BaseResponse<T>(
     val isSuccess: Boolean = false,
     val code: Int = 0,
     val message: String? = null,
-    val result: T
+    val result: T? = null,
+    val timestamp: String? = null,
+    val status: Int? = null,
+    val error: String? = null,
+    val path: String? = null
 )

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/request/PostLoginRequest.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/request/PostLoginRequest.kt
@@ -1,6 +1,8 @@
 package com.jinkyu.tv.data.model.request
 
+import kotlinx.serialization.Serializable
+
 data class PostLoginRequest(
-    val id: String,
+    @Serializable("id") val id: String,
     val password: String
 )

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/request/PostLoginRequest.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/request/PostLoginRequest.kt
@@ -2,7 +2,8 @@ package com.jinkyu.tv.data.model.request
 
 import kotlinx.serialization.Serializable
 
+@Serializable
 data class PostLoginRequest(
-    @Serializable("id") val id: String,
+    val id: String,
     val password: String
 )

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/request/PostRegisterRequest.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/request/PostRegisterRequest.kt
@@ -1,7 +1,10 @@
 package com.jinkyu.tv.data.model.request
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class PostRegisterRequest(
-    val nickName: String,
+    val userName: String,
     val id: String,
     val email: String,
     val password: String

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/response/PostLoginResponse.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/response/PostLoginResponse.kt
@@ -1,5 +1,8 @@
 package com.jinkyu.tv.data.model.response
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class PostLoginResponse(
     val jwt: String,
     val userIdx: Int

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/response/PostLoginResponse.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/response/PostLoginResponse.kt
@@ -5,5 +5,6 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class PostLoginResponse(
     val jwt: String,
-    val userIdx: Int
+    val userIdx: Int,
+    val userName: String
 )

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/response/PostRegisterResponse.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/data/model/response/PostRegisterResponse.kt
@@ -1,5 +1,8 @@
 package com.jinkyu.tv.data.model.response
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class PostRegisterResponse(
     val jwt: String,
     val userIdx: Int

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginNavigationAction.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginNavigationAction.kt
@@ -1,0 +1,6 @@
+package com.jinkyu.tv.presentation.login
+
+sealed class LoginNavigationAction {
+    data object NavigateToMain : LoginNavigationAction()
+    data object NavigateRegister : LoginNavigationAction()
+}

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginScreen.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginScreen.kt
@@ -5,13 +5,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.jinkyu.tv.domain.user.UserInput
-import com.jinkyu.tv.presentation.login.LoginViewModel
 import com.jinkyu.tv.ui.Divider
 import com.jinkyu.tv.ui.DividerWeight
 import com.jinkyu.tv.ui.EmailHint
@@ -33,6 +33,7 @@ import com.jinkyu.tv.ui.system.JinKyuTextField
 import com.jinkyu.tv.ui.system.Label
 import com.jinkyu.tv.ui.system.RememberCheckBox
 import com.jinkyu.tv.ui.system.WelcomeLabel
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun LoginScreen(
@@ -41,6 +42,15 @@ fun LoginScreen(
     modifier: Modifier = Modifier,
     viewModel: LoginViewModel
 ) {
+    LaunchedEffect(Unit) {
+        viewModel.navigationAction.collectLatest { navigation ->
+            when (navigation) {
+                LoginNavigationAction.NavigateToMain -> navigateMain()
+                LoginNavigationAction.NavigateRegister -> navigateRegister()
+            }
+        }
+    }
+
     val email by viewModel.email.collectAsState()
     val password by viewModel.password.collectAsState()
     val loginEnable by viewModel.loginEnable.collectAsState()

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginScreen.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginScreen.kt
@@ -18,7 +18,6 @@ import com.jinkyu.tv.ui.DividerWeight
 import com.jinkyu.tv.ui.EmailHint
 import com.jinkyu.tv.ui.EmailLabel
 import com.jinkyu.tv.ui.HaveNotAccount
-import com.jinkyu.tv.ui.LoginLabel
 import com.jinkyu.tv.ui.LoginMessage1
 import com.jinkyu.tv.ui.LoginMessage2
 import com.jinkyu.tv.ui.PasswordHint
@@ -55,6 +54,7 @@ fun LoginScreen(
     val password by viewModel.password.collectAsState()
     val loginEnable by viewModel.loginEnable.collectAsState()
     val rememberMe by viewModel.rememberMe.collectAsState()
+    val loginLabel by viewModel.error.collectAsState()
 
     Column(
         modifier = Modifier.fillMaxSize().background(Color.White).padding(horizontal = 26.dp)
@@ -87,7 +87,7 @@ fun LoginScreen(
         Divider(height = 80)
         DividerWeight()
         Button(
-            buttonLabel = LoginLabel,
+            buttonLabel = loginLabel,
             enable = loginEnable,
             onClicked = { viewModel.onLoginClicked() }
         )

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginScreen.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginScreen.kt
@@ -1,4 +1,4 @@
-package com.jinkyu.tv
+package com.jinkyu.tv.presentation.login
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
@@ -11,20 +11,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.jinkyu.tv.domain.user.UserInput
-import com.jinkyu.tv.presentation.RegisterViewModel
-import com.jinkyu.tv.ui.AlreadyHaveAccount
+import com.jinkyu.tv.presentation.login.LoginViewModel
 import com.jinkyu.tv.ui.Divider
 import com.jinkyu.tv.ui.DividerWeight
 import com.jinkyu.tv.ui.EmailHint
 import com.jinkyu.tv.ui.EmailLabel
+import com.jinkyu.tv.ui.HaveNotAccount
 import com.jinkyu.tv.ui.LoginLabel
-import com.jinkyu.tv.ui.NicknameHint
-import com.jinkyu.tv.ui.NicknameLabel
+import com.jinkyu.tv.ui.LoginMessage1
+import com.jinkyu.tv.ui.LoginMessage2
 import com.jinkyu.tv.ui.PasswordHint
 import com.jinkyu.tv.ui.PasswordLabel
 import com.jinkyu.tv.ui.SignUpLabel
-import com.jinkyu.tv.ui.SignUpMessage1
-import com.jinkyu.tv.ui.SignUpMessage2
 import com.jinkyu.tv.ui.SocialLoginButtons
 import com.jinkyu.tv.ui.SocialLoginDivider
 import com.jinkyu.tv.ui.system.AlreadyTextButton
@@ -37,15 +35,15 @@ import com.jinkyu.tv.ui.system.RememberCheckBox
 import com.jinkyu.tv.ui.system.WelcomeLabel
 
 @Composable
-fun RegisterScreen(
-    navigateLogin: () -> Unit,
+fun LoginScreen(
+    navigateRegister: () -> Unit,
+    navigateMain: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: RegisterViewModel
+    viewModel: LoginViewModel
 ) {
-    val nickName by viewModel.nickName.collectAsState()
     val email by viewModel.email.collectAsState()
     val password by viewModel.password.collectAsState()
-    val registerEnable by viewModel.registerEnable.collectAsState()
+    val loginEnable by viewModel.loginEnable.collectAsState()
     val rememberMe by viewModel.rememberMe.collectAsState()
 
     Column(
@@ -53,15 +51,8 @@ fun RegisterScreen(
     ) {
         AppLogoLabel()
         WelcomeLabel(
-            firstLabel = SignUpMessage1,
-            secondLabel = SignUpMessage2
-        )
-        Label(label = NicknameLabel)
-        JinKyuTextField(
-            modifier = Modifier.fillMaxWidth(),
-            text = nickName,
-            onValueChange = { viewModel.onUserInput(type = UserInput.NICKNAME, input = it) },
-            hint = NicknameHint
+            firstLabel = LoginMessage1,
+            secondLabel = LoginMessage2
         )
         Label(label = EmailLabel)
         JinKyuTextField(
@@ -81,24 +72,25 @@ fun RegisterScreen(
         RememberCheckBox(
             rememberMe = rememberMe,
             onCheckBoxClicked = { viewModel.onRememberMeClicked(it) },
-            onForgotPasswordClicked = {  }
+            onForgotPasswordClicked = { viewModel.onSignUpClicked() }
         )
+        Divider(height = 80)
         DividerWeight()
         Button(
-            buttonLabel = SignUpLabel,
-            enable = registerEnable,
-            onClicked = { viewModel.onSignUpClicked() }
+            buttonLabel = LoginLabel,
+            enable = loginEnable,
+            onClicked = { viewModel.onLoginClicked() }
         )
         SocialLoginDivider()
         SocialLoginButtons(
-            onGitHubButtonClicked = { viewModel.onBackButtonClicked() },
-            onGitLabButtonClicked = { viewModel.onBackButtonClicked() }
+            onGitHubButtonClicked = { viewModel.onSignUpClicked() },
+            onGitLabButtonClicked = { viewModel.onSignUpClicked() }
         )
         DividerWeight()
         AlreadyTextButton(
-            message = AlreadyHaveAccount,
-            buttonLabel = LoginLabel,
-            onButtonClicked = { viewModel.onBackButtonClicked() }
+            message = HaveNotAccount,
+            buttonLabel = SignUpLabel,
+            onButtonClicked = { viewModel.onSignUpClicked() }
         )
         Divider(height = 18)
     }

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginScreen.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginScreen.kt
@@ -2,6 +2,7 @@ package com.jinkyu.tv.presentation.login
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -39,7 +40,6 @@ import kotlinx.coroutines.flow.collectLatest
 fun LoginScreen(
     navigateRegister: () -> Unit,
     navigateMain: () -> Unit,
-    modifier: Modifier = Modifier,
     viewModel: LoginViewModel
 ) {
     LaunchedEffect(Unit) {
@@ -57,7 +57,7 @@ fun LoginScreen(
     val rememberMe by viewModel.rememberMe.collectAsState()
 
     Column(
-        modifier = modifier.background(Color.White).padding(horizontal = 26.dp)
+        modifier = Modifier.fillMaxSize().background(Color.White).padding(horizontal = 26.dp)
     ) {
         AppLogoLabel()
         WelcomeLabel(

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginScreen.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginScreen.kt
@@ -34,12 +34,13 @@ import com.jinkyu.tv.ui.system.Label
 import com.jinkyu.tv.ui.system.RememberCheckBox
 import com.jinkyu.tv.ui.system.WelcomeLabel
 import kotlinx.coroutines.flow.collectLatest
+import org.koin.compose.koinInject
 
 @Composable
 fun LoginScreen(
     navigateRegister: () -> Unit,
     navigateMain: () -> Unit,
-    viewModel: LoginViewModel
+    viewModel: LoginViewModel = koinInject()
 ) {
     LaunchedEffect(Unit) {
         viewModel.navigationAction.collectLatest { navigation ->

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginViewModel.kt
@@ -2,7 +2,6 @@ package com.jinkyu.tv.presentation.login
 
 import com.jinkyu.tv.data.UserRepository
 import com.jinkyu.tv.domain.user.UserInput
-import com.jinkyu.tv.presentation.register.RegisterNavigationAction
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -25,8 +24,8 @@ class LoginViewModel(
     private val _navigationAction: MutableSharedFlow<LoginNavigationAction> = MutableSharedFlow<LoginNavigationAction>()
     val navigationAction: SharedFlow<LoginNavigationAction> = _navigationAction.asSharedFlow()
 
-    private val _error: MutableSharedFlow<String> = MutableSharedFlow<String>()
-    val error: SharedFlow<String> = _error.asSharedFlow()
+    private val _error: MutableStateFlow<String> = MutableStateFlow<String>("Login")
+    val error: StateFlow<String> = _error.asStateFlow()
 
     private val _email: MutableStateFlow<String> = MutableStateFlow<String>("")
     val email: StateFlow<String> = _email.asStateFlow()
@@ -51,6 +50,7 @@ class LoginViewModel(
             UserInput.PASSWORD -> _password.value = input
             else -> {}
         }
+        _error.value = "Login"
     }
 
     fun onSignUpClicked() {
@@ -67,7 +67,7 @@ class LoginViewModel(
                     _navigationAction.emit(LoginNavigationAction.NavigateToMain)
                 }
                 result.throwable?.let {
-                    _error.emit(it.toString())
+                    _error.emit(it.message ?: "")
                 }
             }
         }

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginViewModel.kt
@@ -1,19 +1,27 @@
 package com.jinkyu.tv.presentation.login
 
 import com.jinkyu.tv.domain.user.UserInput
+import com.jinkyu.tv.presentation.register.RegisterNavigationAction
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 class LoginViewModel(
     private val coroutineScope: CoroutineScope? = null
 ) {
     private val viewModelScope = coroutineScope ?: CoroutineScope(Dispatchers.Main)
+
+    private val _navigationAction: MutableSharedFlow<LoginNavigationAction> = MutableSharedFlow<LoginNavigationAction>()
+    val navigationAction: SharedFlow<LoginNavigationAction> = _navigationAction.asSharedFlow()
 
     private val _email: MutableStateFlow<String> = MutableStateFlow<String>("")
     val email: StateFlow<String> = _email.asStateFlow()
@@ -40,9 +48,17 @@ class LoginViewModel(
         }
     }
 
-    fun onSignUpClicked() {}
+    fun onSignUpClicked() {
+        viewModelScope.launch {
+            _navigationAction.emit(LoginNavigationAction.NavigateRegister)
+        }
+    }
 
-    fun onLoginClicked() {}
+    fun onLoginClicked() {
+        viewModelScope.launch {
+            if (loginEnable.value) _navigationAction.emit(LoginNavigationAction.NavigateToMain)
+        }
+    }
 
     fun onRememberMeClicked(enable: Boolean) {
         _rememberMe.value = enable

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/login/LoginViewModel.kt
@@ -1,4 +1,4 @@
-package com.jinkyu.tv.presentation
+package com.jinkyu.tv.presentation.login
 
 import com.jinkyu.tv.domain.user.UserInput
 import kotlinx.coroutines.CoroutineScope
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 
-class RegisterViewModel(
+class LoginViewModel(
     private val coroutineScope: CoroutineScope? = null
 ) {
     private val viewModelScope = coroutineScope ?: CoroutineScope(Dispatchers.Main)
@@ -18,14 +18,11 @@ class RegisterViewModel(
     private val _email: MutableStateFlow<String> = MutableStateFlow<String>("")
     val email: StateFlow<String> = _email.asStateFlow()
 
-    private val _nickName: MutableStateFlow<String> = MutableStateFlow<String>("")
-    val nickName: StateFlow<String> = _nickName.asStateFlow()
-
     private val _password: MutableStateFlow<String> = MutableStateFlow<String>("")
     val password: StateFlow<String> = _password.asStateFlow()
 
-    val registerEnable: StateFlow<Boolean> = combine(_email, _nickName, _password) { email, nickName, password ->
-        email.isNotBlank() && nickName.isNotBlank() && password.isNotBlank()
+    val loginEnable: StateFlow<Boolean> = combine(_email, _password) { email, password ->
+        email.isNotBlank() && password.isNotBlank()
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),
@@ -37,15 +34,15 @@ class RegisterViewModel(
 
     fun onUserInput(type: UserInput, input: String) {
         when (type) {
-            UserInput.NICKNAME -> _nickName.value = input
             UserInput.EMAIL -> _email.value = input
             UserInput.PASSWORD -> _password.value = input
+            else -> {}
         }
     }
 
     fun onSignUpClicked() {}
 
-    fun onBackButtonClicked() {}
+    fun onLoginClicked() {}
 
     fun onRememberMeClicked(enable: Boolean) {
         _rememberMe.value = enable

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterNavigationAction.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterNavigationAction.kt
@@ -1,0 +1,6 @@
+package com.jinkyu.tv.presentation.register
+
+sealed class RegisterNavigationAction {
+    data object NavigateToMain : RegisterNavigationAction()
+    data object NavigateLogin : RegisterNavigationAction()
+}

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterScreen.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterScreen.kt
@@ -37,12 +37,13 @@ import com.jinkyu.tv.ui.system.Label
 import com.jinkyu.tv.ui.system.RememberCheckBox
 import com.jinkyu.tv.ui.system.WelcomeLabel
 import kotlinx.coroutines.flow.collectLatest
+import org.koin.compose.koinInject
 
 @Composable
 fun RegisterScreen(
     navigateLogin: () -> Unit,
     navigateMain: () -> Unit,
-    viewModel: RegisterViewModel
+    viewModel: RegisterViewModel = koinInject()
 ) {
     LaunchedEffect(Unit) {
         viewModel.navigationAction.collectLatest { navigation ->

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterScreen.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterScreen.kt
@@ -1,28 +1,30 @@
-package com.jinkyu.tv
+package com.jinkyu.tv.presentation.register
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.jinkyu.tv.domain.user.UserInput
-import com.jinkyu.tv.presentation.LoginViewModel
+import com.jinkyu.tv.ui.AlreadyHaveAccount
 import com.jinkyu.tv.ui.Divider
 import com.jinkyu.tv.ui.DividerWeight
 import com.jinkyu.tv.ui.EmailHint
 import com.jinkyu.tv.ui.EmailLabel
-import com.jinkyu.tv.ui.HaveNotAccount
 import com.jinkyu.tv.ui.LoginLabel
-import com.jinkyu.tv.ui.LoginMessage1
-import com.jinkyu.tv.ui.LoginMessage2
+import com.jinkyu.tv.ui.NicknameHint
+import com.jinkyu.tv.ui.NicknameLabel
 import com.jinkyu.tv.ui.PasswordHint
 import com.jinkyu.tv.ui.PasswordLabel
 import com.jinkyu.tv.ui.SignUpLabel
+import com.jinkyu.tv.ui.SignUpMessage1
+import com.jinkyu.tv.ui.SignUpMessage2
 import com.jinkyu.tv.ui.SocialLoginButtons
 import com.jinkyu.tv.ui.SocialLoginDivider
 import com.jinkyu.tv.ui.system.AlreadyTextButton
@@ -35,15 +37,25 @@ import com.jinkyu.tv.ui.system.RememberCheckBox
 import com.jinkyu.tv.ui.system.WelcomeLabel
 
 @Composable
-fun LoginScreen(
-    navigateRegister: () -> Unit,
+fun RegisterScreen(
+    navigateLogin: () -> Unit,
     navigateMain: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: LoginViewModel
+    viewModel: RegisterViewModel
 ) {
+    LaunchedEffect(true) {
+        viewModel.navigationAction.collect { effect ->
+            when (effect) {
+                RegisterNavigationAction.NavigateToMain -> navigateMain()
+                RegisterNavigationAction.NavigateLogin -> navigateLogin()
+            }
+        }
+    }
+
+    val nickName by viewModel.nickName.collectAsState()
     val email by viewModel.email.collectAsState()
     val password by viewModel.password.collectAsState()
-    val loginEnable by viewModel.loginEnable.collectAsState()
+    val registerEnable by viewModel.registerEnable.collectAsState()
     val rememberMe by viewModel.rememberMe.collectAsState()
 
     Column(
@@ -51,8 +63,15 @@ fun LoginScreen(
     ) {
         AppLogoLabel()
         WelcomeLabel(
-            firstLabel = LoginMessage1,
-            secondLabel = LoginMessage2
+            firstLabel = SignUpMessage1,
+            secondLabel = SignUpMessage2
+        )
+        Label(label = NicknameLabel)
+        JinKyuTextField(
+            modifier = Modifier.fillMaxWidth(),
+            text = nickName,
+            onValueChange = { viewModel.onUserInput(type = UserInput.NICKNAME, input = it) },
+            hint = NicknameHint
         )
         Label(label = EmailLabel)
         JinKyuTextField(
@@ -72,25 +91,24 @@ fun LoginScreen(
         RememberCheckBox(
             rememberMe = rememberMe,
             onCheckBoxClicked = { viewModel.onRememberMeClicked(it) },
-            onForgotPasswordClicked = { viewModel.onSignUpClicked() }
+            onForgotPasswordClicked = {  }
         )
-        Divider(height = 80)
         DividerWeight()
         Button(
-            buttonLabel = LoginLabel,
-            enable = loginEnable,
-            onClicked = { viewModel.onLoginClicked() }
+            buttonLabel = SignUpLabel,
+            enable = registerEnable,
+            onClicked = { viewModel.onSignUpClicked() }
         )
         SocialLoginDivider()
         SocialLoginButtons(
-            onGitHubButtonClicked = { viewModel.onSignUpClicked() },
-            onGitLabButtonClicked = { viewModel.onSignUpClicked() }
+            onGitHubButtonClicked = { viewModel.onBackButtonClicked() },
+            onGitLabButtonClicked = { viewModel.onBackButtonClicked() }
         )
         DividerWeight()
         AlreadyTextButton(
-            message = HaveNotAccount,
-            buttonLabel = SignUpLabel,
-            onButtonClicked = { viewModel.onSignUpClicked() }
+            message = AlreadyHaveAccount,
+            buttonLabel = LoginLabel,
+            onButtonClicked = { viewModel.onBackButtonClicked() }
         )
         Divider(height = 18)
     }

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterScreen.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterScreen.kt
@@ -2,6 +2,7 @@ package com.jinkyu.tv.presentation.register
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -41,7 +42,6 @@ import kotlinx.coroutines.flow.collectLatest
 fun RegisterScreen(
     navigateLogin: () -> Unit,
     navigateMain: () -> Unit,
-    modifier: Modifier = Modifier,
     viewModel: RegisterViewModel
 ) {
     LaunchedEffect(Unit) {
@@ -60,7 +60,7 @@ fun RegisterScreen(
     val rememberMe by viewModel.rememberMe.collectAsState()
 
     Column(
-        modifier = modifier.background(Color.White).padding(horizontal = 26.dp)
+        modifier = Modifier.fillMaxSize().background(Color.White).padding(horizontal = 26.dp)
     ) {
         AppLogoLabel()
         WelcomeLabel(

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterScreen.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterScreen.kt
@@ -35,6 +35,7 @@ import com.jinkyu.tv.ui.system.JinKyuTextField
 import com.jinkyu.tv.ui.system.Label
 import com.jinkyu.tv.ui.system.RememberCheckBox
 import com.jinkyu.tv.ui.system.WelcomeLabel
+import kotlinx.coroutines.flow.collectLatest
 
 @Composable
 fun RegisterScreen(
@@ -43,9 +44,9 @@ fun RegisterScreen(
     modifier: Modifier = Modifier,
     viewModel: RegisterViewModel
 ) {
-    LaunchedEffect(true) {
-        viewModel.navigationAction.collect { effect ->
-            when (effect) {
+    LaunchedEffect(Unit) {
+        viewModel.navigationAction.collectLatest { navigation ->
+            when (navigation) {
                 RegisterNavigationAction.NavigateToMain -> navigateMain()
                 RegisterNavigationAction.NavigateLogin -> navigateLogin()
             }

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterScreen.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterScreen.kt
@@ -58,6 +58,7 @@ fun RegisterScreen(
     val password by viewModel.password.collectAsState()
     val registerEnable by viewModel.registerEnable.collectAsState()
     val rememberMe by viewModel.rememberMe.collectAsState()
+    val signUpLabel by viewModel.error.collectAsState()
 
     Column(
         modifier = Modifier.fillMaxSize().background(Color.White).padding(horizontal = 26.dp)
@@ -96,7 +97,7 @@ fun RegisterScreen(
         )
         DividerWeight()
         Button(
-            buttonLabel = SignUpLabel,
+            buttonLabel = signUpLabel,
             enable = registerEnable,
             onClicked = { viewModel.onSignUpClicked() }
         )

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterViewModel.kt
@@ -1,6 +1,7 @@
 package com.jinkyu.tv.presentation.register
 
 import com.jinkyu.tv.domain.user.UserInput
+import com.jinkyu.tv.presentation.login.LoginNavigationAction
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -50,7 +51,11 @@ class RegisterViewModel(
         }
     }
 
-    fun onSignUpClicked() {}
+    fun onSignUpClicked() {
+        viewModelScope.launch {
+            if (registerEnable.value) _navigationAction.emit(RegisterNavigationAction.NavigateToMain)
+        }
+    }
 
     fun onBackButtonClicked() {
         viewModelScope.launch {

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/register/RegisterViewModel.kt
@@ -1,28 +1,38 @@
-package com.jinkyu.tv.presentation
+package com.jinkyu.tv.presentation.register
 
 import com.jinkyu.tv.domain.user.UserInput
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
-class LoginViewModel(
+class RegisterViewModel(
     private val coroutineScope: CoroutineScope? = null
 ) {
     private val viewModelScope = coroutineScope ?: CoroutineScope(Dispatchers.Main)
 
+    private val _navigationAction: MutableSharedFlow<RegisterNavigationAction> = MutableSharedFlow<RegisterNavigationAction>()
+    val navigationAction: SharedFlow<RegisterNavigationAction> = _navigationAction.asSharedFlow()
+
     private val _email: MutableStateFlow<String> = MutableStateFlow<String>("")
     val email: StateFlow<String> = _email.asStateFlow()
+
+    private val _nickName: MutableStateFlow<String> = MutableStateFlow<String>("")
+    val nickName: StateFlow<String> = _nickName.asStateFlow()
 
     private val _password: MutableStateFlow<String> = MutableStateFlow<String>("")
     val password: StateFlow<String> = _password.asStateFlow()
 
-    val loginEnable: StateFlow<Boolean> = combine(_email, _password) { email, password ->
-        email.isNotBlank() && password.isNotBlank()
+    val registerEnable: StateFlow<Boolean> = combine(_email, _nickName, _password) { email, nickName, password ->
+        email.isNotBlank() && nickName.isNotBlank() && password.isNotBlank()
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),
@@ -34,15 +44,19 @@ class LoginViewModel(
 
     fun onUserInput(type: UserInput, input: String) {
         when (type) {
+            UserInput.NICKNAME -> _nickName.value = input
             UserInput.EMAIL -> _email.value = input
             UserInput.PASSWORD -> _password.value = input
-            else -> {}
         }
     }
 
     fun onSignUpClicked() {}
 
-    fun onLoginClicked() {}
+    fun onBackButtonClicked() {
+        viewModelScope.launch {
+            _navigationAction.emit(RegisterNavigationAction.NavigateLogin)
+        }
+    }
 
     fun onRememberMeClicked(enable: Boolean) {
         _rememberMe.value = enable

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/splash/SplashEffect.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/splash/SplashEffect.kt
@@ -2,5 +2,5 @@ package com.jinkyu.tv.presentation.splash
 
 sealed interface SplashEffect {
     data object NavigateMain : SplashEffect
-    data object NavigateSign : SplashEffect
+    data object NavigateLogin : SplashEffect
 }

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/splash/SplashScreen.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/splash/SplashScreen.kt
@@ -15,14 +15,14 @@ import org.koin.compose.koinInject
 @Composable
 fun SplashScreen(
     navigateMain: () -> Unit,
-    navigateSign: () -> Unit,
+    navigateLogin: () -> Unit,
     viewModel: SplashViewModel = koinInject(),
 ) {
     LaunchedEffect(true) {
         viewModel.effect.collect { effect ->
             when (effect) {
                 SplashEffect.NavigateMain -> navigateMain()
-                SplashEffect.NavigateSign -> navigateSign()
+                SplashEffect.NavigateLogin -> navigateLogin()
             }
         }
     }

--- a/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/splash/SplashViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/jinkyu/tv/presentation/splash/SplashViewModel.kt
@@ -19,7 +19,7 @@ class SplashViewModel(
     init {
         viewModelScope.launch {
             delay(1000L)
-            _effect.emit(SplashEffect.NavigateMain)
+            _effect.emit(SplashEffect.NavigateLogin)
         }
     }
 }

--- a/shared/src/iosMain/kotlin/com/jinkyu/tv/KoinHelper.kt
+++ b/shared/src/iosMain/kotlin/com/jinkyu/tv/KoinHelper.kt
@@ -1,10 +1,17 @@
 package com.jinkyu.tv
 
+import com.jinkyu.tv.presentation.login.LoginViewModel
 import com.jinkyu.tv.presentation.player.PlayerViewModel
+import com.jinkyu.tv.presentation.register.RegisterViewModel
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
 class KoinHelper : KoinComponent {
     private val playerViewModel: PlayerViewModel by inject()
-    fun playerViewModel():PlayerViewModel = playerViewModel
+    private val registerViewModel: RegisterViewModel by inject()
+    private val loginViewModel: LoginViewModel by inject()
+
+    fun playerViewModel(): PlayerViewModel = playerViewModel
+    fun registerViewModel(): RegisterViewModel = registerViewModel
+    fun loginViewModel(): LoginViewModel = loginViewModel
 }

--- a/shared/src/iosMain/kotlin/com/jinkyu/tv/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/com/jinkyu/tv/Platform.ios.kt
@@ -9,6 +9,8 @@ import androidx.compose.ui.interop.UIKitView
 import com.jinkyu.tv.presentation.MainViewModel
 import com.jinkyu.tv.presentation.player.PlayerViewModel
 import com.jinkyu.tv.presentation.splash.SplashViewModel
+import com.jinkyu.tv.presentation.login.LoginViewModel
+import com.jinkyu.tv.presentation.register.RegisterViewModel
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
 import org.koin.core.module.dsl.factoryOf
@@ -34,6 +36,12 @@ actual fun platformModule() = module {
     }
     factory {
         PlayerViewModel()
+    }
+    factory {
+        RegisterViewModel(null)
+    }
+    factory {
+        LoginViewModel(null)
     }
 }
 

--- a/shared/src/iosMain/kotlin/com/jinkyu/tv/Platform.ios.kt
+++ b/shared/src/iosMain/kotlin/com/jinkyu/tv/Platform.ios.kt
@@ -6,27 +6,39 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.interop.UIKitView
+import com.jinkyu.tv.data.UserRepository
+import com.jinkyu.tv.data.UserRepositoryImpl
 import com.jinkyu.tv.presentation.MainViewModel
-import com.jinkyu.tv.presentation.player.PlayerViewModel
-import com.jinkyu.tv.presentation.splash.SplashViewModel
 import com.jinkyu.tv.presentation.login.LoginViewModel
+import com.jinkyu.tv.presentation.player.PlayerViewModel
 import com.jinkyu.tv.presentation.register.RegisterViewModel
+import com.jinkyu.tv.presentation.splash.SplashViewModel
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.darwin.Darwin
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.serialization.kotlinx.json.json
 import kotlinx.cinterop.CValue
 import kotlinx.cinterop.ExperimentalForeignApi
-import org.koin.core.module.dsl.factoryOf
 import org.koin.dsl.module
-import platform.AVFoundation.AVPlayer
 import platform.AVFoundation.AVPlayerLayer
 import platform.AVFoundation.play
 import platform.AVKit.AVPlayerViewController
 import platform.CoreGraphics.CGRect
-import platform.Foundation.NSURL
 import platform.QuartzCore.CATransaction
 import platform.QuartzCore.kCATransactionDisableActions
 import platform.UIKit.UIView
 
 
 actual fun platformModule() = module {
+    single<HttpClient> {
+        HttpClient(Darwin) {
+            install(ContentNegotiation) {
+                json()
+            }
+        }
+
+    }
+    single<UserRepository> { UserRepositoryImpl(get()) }
     factory {
         MainViewModel()
     }
@@ -38,10 +50,10 @@ actual fun platformModule() = module {
         PlayerViewModel()
     }
     factory {
-        RegisterViewModel(null)
+        RegisterViewModel(null, it.get())
     }
     factory {
-        LoginViewModel(null)
+        LoginViewModel(null, it.get())
     }
 }
 

--- a/shared/src/iosMain/kotlin/com/jinkyu/tv/main.ios.kt
+++ b/shared/src/iosMain/kotlin/com/jinkyu/tv/main.ios.kt
@@ -16,12 +16,12 @@ import platform.UIKit.UIViewController
 
 fun SplashViewController(
     navigateMain: () -> Unit,
-    navigateSign: () -> Unit
+    navigateLogin: () -> Unit
 ): UIViewController {
     return ComposeUIViewController {
         SplashScreen(
             navigateMain = navigateMain,
-            navigateSign = navigateSign,
+            navigateLogin = navigateLogin,
         )
     }
 }

--- a/shared/src/iosMain/kotlin/com/jinkyu/tv/main.ios.kt
+++ b/shared/src/iosMain/kotlin/com/jinkyu/tv/main.ios.kt
@@ -2,7 +2,9 @@ package com.jinkyu.tv
 
 import androidx.compose.ui.uikit.ComposeUIViewControllerDelegate
 import androidx.compose.ui.window.ComposeUIViewController
+import com.jinkyu.tv.presentation.login.LoginScreen
 import com.jinkyu.tv.presentation.player.PlayerViewModel
+import com.jinkyu.tv.presentation.register.RegisterScreen
 import com.jinkyu.tv.presentation.splash.SplashScreen
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.coroutineScope
@@ -22,6 +24,30 @@ fun SplashViewController(
         SplashScreen(
             navigateMain = navigateMain,
             navigateLogin = navigateLogin,
+        )
+    }
+}
+
+fun LoginViewController(
+    navigateRegister: () -> Unit,
+    navigateMain: () -> Unit,
+): UIViewController {
+    return ComposeUIViewController {
+        LoginScreen(
+            navigateRegister = navigateRegister,
+            navigateMain = navigateMain
+        )
+    }
+}
+
+fun RegisterViewController(
+    navigateLogin: () -> Unit,
+    navigateMain: () -> Unit,
+): UIViewController {
+    return ComposeUIViewController {
+        RegisterScreen(
+            navigateLogin = navigateLogin,
+            navigateMain = navigateMain
         )
     }
 }

--- a/shared/src/iosMain/kotlin/com/jinkyu/tv/presentation/player/PlayerViewModel.kt
+++ b/shared/src/iosMain/kotlin/com/jinkyu/tv/presentation/player/PlayerViewModel.kt
@@ -1,6 +1,5 @@
 package com.jinkyu.tv.presentation.player
 
-import androidx.compose.ui.uikit.ComposeUIViewControllerDelegate
 import platform.AVFoundation.AVPlayer
 import platform.AVFoundation.pause
 import platform.AVFoundation.play


### PR DESCRIPTION
### 작업 내용
1. 로그인 API 연동
2. 회원가입 API 연동
3. 유저 이름 가져오는 함수 추가(다음 PR에서 SQLDelight를 사용해서 로컬에 저장하는 내용 진행)

### 참고사항
- 아래의 함수로 유저 이름 가져오도록 추가 
- (단, 로그인 하거나 회원가입을 한 경우에만 가능. 현재 캐싱처럼 들고 있음)
- 추후 PR에서 SqlDelight 연동하면 로컬에서 자동로그인 & 유저 이름 사용 가능
~~~kotlin
userRepository.getUserName() 
~~~